### PR TITLE
Revisit build setup and remove vs. wrap propTypes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
   "presets": [["env", {"modules": false}], "react"],
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-react-remove-prop-types",
+      { "mode": "wrap" }
+    ]
+  ],
   "env": {
     "test": {
       "presets": [["env"], "react"]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.13",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
+    "cross-env": "5.1.3",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "jest": "22.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   ],
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "NODE_ENV=production rollup -c",
+    "build": "npm run build:dev && npm run build:prod",
+    "build:dev": "rollup -c",
+    "build:prod": "cross-env NODE_ENV=production rollup -c",
     "clean": "rimraf dist/*",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,8 @@ import babel from 'rollup-plugin-babel';
 import uglify from 'rollup-plugin-uglify';
 import pkg from './package.json';
 
+const NODE_ENV = process.env.NODE_ENV || 'development';
+
 function minify(config) {
   return Object.assign({}, config, {
     output: Object.assign({}, config.output, {
@@ -48,4 +50,6 @@ const esConfig = Object.assign({}, baseConfig, {
   output: {file: pkg.module, format: 'es'},
 });
 
-export default [umdConfig, minify(umdConfig), cjsConfig, esConfig];
+export default (NODE_ENV === 'production'
+  ? [minify(umdConfig)]
+  : [umdConfig, cjsConfig, esConfig]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,7 +972,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.1:
+cross-env@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1824,6 +1831,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Related to https://github.com/erikthedeveloper/react-render-watch/pull/1 specifically this comment: https://github.com/erikthedeveloper/react-render-watch/pull/1/files#r171872033

If we "remove" propTypes from the build altogether (including CJS, ESM, UMD) then we lose the benefit of having propTypes at all since users will no longer receive warnings when providing invalid props, even when they are running in development mode. It appears to me that this is removing propTypes for all `dist/*.js` output files.

The cause of the problem was the fault of my build setup/`.babelrc` since the "production" settings were being applied to all builds. See:

**Before:**

https://github.com/jamesplease/react-render-watch/blob/a2374c5dc27663eb99c560b3744ba6e4ed35d869/.babelrc#L7-L15

https://github.com/jamesplease/react-render-watch/blob/a2374c5dc27663eb99c560b3744ba6e4ed35d869/package.json#L13

### "remove" propTypes for umd.min.js otherwise "wrap"

![image](https://user-images.githubusercontent.com/1240178/36909048-360e652c-1dfa-11e8-9b8d-0f20d19aa981.png)

![image](https://user-images.githubusercontent.com/1240178/36909622-be398d54-1dfb-11e8-86f4-5319694a9f91.png)

**After**

See changes introduced in this PR

### Output size comparison

**Before**

```
➜  react-render-watch git:(jamesplease-things) gzip-size dist/react-render-watch.cjs.js
939 B
➜  react-render-watch git:(jamesplease-things) gzip-size dist/react-render-watch.umd.min.js
728 B
```

**After**

```
➜  react-render-watch git:(build-stuffs) gzip-size dist/react-render-watch.cjs.js
1.02 kB
➜  react-render-watch git:(build-stuffs) gzip-size dist/react-render-watch.umd.min.js
728 B
```